### PR TITLE
Check for write perm on gplink attribute of an OU

### DIFF
--- a/abuseACL/structures/structures.py
+++ b/abuseACL/structures/structures.py
@@ -50,6 +50,5 @@ class RIGHTS_GUID(Enum):
     # All
     ALL                             = "00000000-0000-0000-0000-000000000000"
 
-    # Attribute gPLink
-    ManageGPLink                    = "f30e3bbf-9ff0-11d1-b603-0000f80367c1"
-
+    # Edit the "gpLink" attribute of the object.
+    MANAGE_GP_LINK                  = "f30e3bbf-9ff0-11d1-b603-0000f80367c1"

--- a/abuseACL/structures/structures.py
+++ b/abuseACL/structures/structures.py
@@ -49,3 +49,7 @@ class RIGHTS_GUID(Enum):
 
     # All
     ALL                             = "00000000-0000-0000-0000-000000000000"
+
+    # Attribute gPLink
+    ManageGPLink                    = "f30e3bbf-9ff0-11d1-b603-0000f80367c1"
+


### PR DESCRIPTION
Added a check for the "Manage Group Policy Link" permission on OUs based on this blog : https://www.synacktiv.com/publications/ounedpy-exploiting-hidden-organizational-units-acl-attack-vectors-in-active-directory